### PR TITLE
🔧 Add :astro preset to Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>derteaser/renovate-presets"
+    "github>derteaser/renovate-presets",
+    "github>derteaser/renovate-presets:astro"
   ]
 }


### PR DESCRIPTION
## Summary

Adds a stack-specific preset from [derteaser/renovate-presets](https://github.com/derteaser/renovate-presets) on top of the existing universal baseline.

## Why

The preset repo now ships ecosystem-specific named presets. Adding the matching one here layers stack-specific groupings on top of the shared defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)